### PR TITLE
Update redirect for Netlify default subdomain (#5)

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -12,7 +12,7 @@ https://vegaprotocol.com/* https://vega.xyz/:splat 301!
 https://www.vegaprotocol.io/* https://vega.xyz/:splat 301!
 
 # Optional: Redirect default Netlify subdomain to primary domain
-https://vega.netlify.com/* https://vega.xyz/:splat 301!
+https://vega.netlify.app/* https://vega.xyz/:splat 301!
 
 
 /email/confirm.html  https://vega.xyz/email/confirm    200


### PR DESCRIPTION
This PR updates the redirect for the Netlify default subdomain, which they changed from `mysite.netlify.com` to `mysite.netlify.app`.

Netlify automatically redirect `mysite.netlify.com` to `mysite.netlify.app`, so we don't need to include that in `_redirects`.

Closes #5.