### PR TITLE
Remove info/link about testnet waiting list

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,8 +25,7 @@
 			<div class="hidden-md-up">
 				<p>
 Vega has designed fully automated processes for creating markets on and trading margined derivatives. Markets will be open and decentralised, with pseudonymous participants.</p>
-</p><p>Sign up to be notified when you can use Vega's testnet.</p>
-	    		<p><a href="/email/testnet-signup" class="call-to-action">Sign up</a></p>
+</p><p>Vega's testnet is now open, find out more here: <a href="https://docs.testnet.vega.xyz/">docs.testnet.vega.xyz</a>.</p>
 	    	</div>
 		</div>
 	</div>


### PR DESCRIPTION
Remove info/link about testnet waiting list, direct to testnet docs instead. 