### PR TITLE
Add data cy attr to container

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -2,7 +2,8 @@ import React from "react";
 
 const Container = (props) => {
   return (
-    <div className={props.hideXOverflow ? "overflow-x-hidden" : ""}>
+    <div className={props.hideXOverflow ? "overflow-x-hidden" : ""}
+      {...(props.dataCy ? {'data-cy': 'main'} : {})}>
       <div className="mx-auto px-4 md:px-6 lg:px-8 max-w-[90rem]">
         {props.children}
       </div>

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -3,7 +3,7 @@ import React from "react";
 const Container = (props) => {
   return (
     <div className={props.hideXOverflow ? "overflow-x-hidden" : ""}
-      {...(props.dataCy ? {'data-cy': 'main'} : {})}>
+      {...(props.dataCy ? {'data-cy': props.dataCy} : {})}>
       <div className="mx-auto px-4 md:px-6 lg:px-8 max-w-[90rem]">
         {props.children}
       </div>

--- a/src/pages/careers/index.js
+++ b/src/pages/careers/index.js
@@ -36,7 +36,7 @@ const CareersPage = () => {
         title="Careers at Vega"
         description="Find your career in DeFi. Join the core team at Vega, and help create Web3's native derivatives layer."
       />
-      <Container>
+      <Container dataCy={'main'}>
         <div className="pt-6 lg:pt-16">
           <div className="grid grid-cols-12">
             <div className="relative z-10 col-span-12 col-start-1 row-span-full">

--- a/src/pages/community/contributors.js
+++ b/src/pages/community/contributors.js
@@ -25,7 +25,7 @@ const Contributors = () => {
         title="Contributors"
         description="Explore the people who have made Vega the exciting DeFi solution that it is."
       />
-      <Container>
+      <Container dataCy={'main'}>
         <div className="mb-16 pt-6 lg:pt-16">
           <div className="max-w-[21.25rem] md:max-w-[40rem] lg:max-w-[44rem] mx-auto text-center mb-6 md:mb-12">
             <GlitchTitle level={1} size="medium">

--- a/src/pages/community/index.js
+++ b/src/pages/community/index.js
@@ -56,7 +56,7 @@ const CommunityPage = ({ data }) => {
         />
       </div>
 
-      <Container>
+      <Container dataCy={'main'}>
         <div id="overview" className="pt-16">
           <h1>
             <BoxTitle text="Community" />

--- a/src/pages/develop/index.js
+++ b/src/pages/develop/index.js
@@ -46,7 +46,7 @@ const DevelopPage = ({ data }) => {
         title="Develop with Vega"
         description="Get access to the Vega APIs, contribute to the source code, earn bounties and be rewarded for building the future of DeFi."
       />
-      <Container hideXOverflow={true}>
+      <Container hideXOverflow={true} dataCy={'main'}>
         <div className="pt-6 mb-16 lg:pt-16">
           <div className="md:grid md:grid-cols-12">
             <div className="relative z-10 col-span-8 col-start-1 row-span-full">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,7 +26,7 @@ const IndexPage = () => {
         description="Discover Web3's native derivatives trading platform that is helping DeFi mature."
       />
       <main>
-        <Container>
+        <Container dataCy={'main'}>
           <div className="relative md:mt-12">
             <div className="mx-auto max-w-[50rem]">
               <Planet />

--- a/src/pages/key-concepts/index.js
+++ b/src/pages/key-concepts/index.js
@@ -37,7 +37,7 @@ const KeyConceptsPage = () => {
         title="Key Vega Concepts"
         description="Explore how Vega bridges traditional finance and DeFi to create a bespoke trading alternative."
       />
-      <Container hideXOverflow={true}>
+      <Container hideXOverflow={true} dataCy={'test'}>
         <div className="pt-6 md:grid md:grid-cols-12 mb-20">
           <div className="hidden md:col-span-2 lg:col-span-3 md:block">
             <UniverseLeft className="translate-y-1/4 -translate-x-2/4 xxl:translate-x-0 scale-150" />

--- a/src/pages/papers/index.js
+++ b/src/pages/papers/index.js
@@ -50,7 +50,7 @@ const PapersPage = () => {
         title="Papers & Research"
         description="Check out the technical, economic and mathematical detail - and innovative thinking behind Vega."
       />
-      <Container>
+      <Container dataCy={'main'}>
         <div className="pt-6 lg:pt-16">
           <div className="mb-6 md:mb-16">
             <div className="mb-3">

--- a/src/pages/partners-backers/index.js
+++ b/src/pages/partners-backers/index.js
@@ -108,7 +108,7 @@ const PartnersBackersPage = () => {
         title="Partners & Backers"
         description="Vega is a community and passion project for all our supporters. Explore the organisations fuelling and supporting this endeavour."
       />
-      <Container>
+      <Container dataCy={'main'}>
         <div className="mb-12 pt-6 md:mb-24 lg:pt-16">
           <div className="grid grid-cols-12 gap-6 mb-16 lg:mb-24">
             <div className="col-span-12 md:col-span-4 lg:col-span-6">

--- a/src/pages/talks/index.js
+++ b/src/pages/talks/index.js
@@ -43,7 +43,7 @@ const PapersPage = () => {
         title="Talks"
         description="Dive in to talks and podcasts by the Vega team on crypto derivatives trading."
       />
-      <Container>
+      <Container dataCy={'main'}>
         <div className="pt-6 lg:pt-16">
           <div className="mb-6 md:mb-16">
             <div className="mb-3">

--- a/src/pages/use/index.js
+++ b/src/pages/use/index.js
@@ -18,7 +18,7 @@ const UsePage = () => {
         description="Use the network to get tokens, start staking, configure the network, or trade. And help fuel the DeFi economy."
       />
       <div className="relative z-10">
-        <Container>
+        <Container dataCy={'main'}>
           <div className="mb-12 md:mb-24 lg:pt-16">
             <div className="max-w-[28rem] lg:max-w-[41.875rem]">
               <h1>


### PR DESCRIPTION
Adding an attribute to the Container component, `data-cy`. This has been added so that selectors in end-to-end tests are robust, readable and more easily manageable.

The attr will only be applied if specified on a page's instance of the component. To specify this attribute add `dataCy={string}` to the Container, where `string` is the attribute value, e.g. `<Container dataCy={'main'}>`.

I have added this attribute to the following pages:

/key-concepts
/papers
/talks
/develop
/use
/community
/community/contributors/
/careers
/partners-backers

