### PR TITLE
Moving data-cy attr from div to a Container

### DIFF
--- a/src/pages/key-concepts/index.js
+++ b/src/pages/key-concepts/index.js
@@ -52,7 +52,7 @@ const KeyConceptsPage = () => {
         title="Key Vega Concepts"
         description="Explore how Vega bridges traditional finance and DeFi to create a bespoke trading alternative."
       />
-      <div datacy={"main"}>
+      <div>
         <div className="pt-6 md:grid md:grid-cols-12">
           <div className="hidden md:col-span-2 lg:col-span-3 xl:col-span-2 md:block">
             <UniverseLeft />
@@ -84,7 +84,7 @@ const KeyConceptsPage = () => {
         </div>
       </div>
 
-      <Container>
+      <Container dataCy={"main"}>
         <div className="relative max-w-[26.25rem] mt-4 pt-[10.5rem] mx-auto text-center after:content-[''] after:absolute after:w-px dark:after:bg-white after:bg-black after:top-0 after:h-[8rem] after:left-1/2">
           <h2 className="title-m mb-6">Vega is designed to:</h2>
         </div>


### PR DESCRIPTION
This PR simply moves the data-cy attr to a container - it changed recently and the attr wasn't being picked up - in the HTML we had `dataCy="main"` rather than `data-cy="main"` - the result of this is that one of the tests was failing as data-cy is used as the attr name to select on.