### PR TITLE
Updating data-cy to be hardcoded on div

### DIFF
--- a/src/pages/key-concepts/index.js
+++ b/src/pages/key-concepts/index.js
@@ -52,7 +52,7 @@ const KeyConceptsPage = () => {
         title="Key Vega Concepts"
         description="Explore how Vega bridges traditional finance and DeFi to create a bespoke trading alternative."
       />
-      <div dataCy={"main"}>
+      <div data-cy="main">
         <div>
           <div className="pt-6 md:grid md:grid-cols-12">
             <div className="hidden md:col-span-2 lg:col-span-3 xl:col-span-2 md:block">


### PR DESCRIPTION
Hiya, the data-cy attr is only generated when attached to a container. `dataCy={"main"}` was added to a div so that was in effect hardcoded. I've updated the attr on the div to be `data-cy="main"`, just something to be aware of in case it is added to a div/non-Container component in the future.