### PR TITLE
Redirect to builders club register interest form

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -5,3 +5,4 @@
 /assets/vega-technical-overview.pdf /papers/vega-technical-overview.pdf 301
 /assets/vega-protocol-whitepaper.pdf  /papers/vega-protocol-whitepaper.pdf  301
 /assets/Wendy_Grows_Up.pdf  /papers/Wendy_Grows_Up.pdf  301
+/buildersclubform      https://vegaprotocol.typeform.com/to/YgOgiGqF  301


### PR DESCRIPTION
This adds a redirect URL that is needed for Builders Club to support our work and also our BC recruitment on the ground at ETHcc