### PR TITLE
Update card title on governance page

### DIFF
--- a/src/pages/governance/index.js
+++ b/src/pages/governance/index.js
@@ -134,7 +134,7 @@ const GovernancePage = ({ data }) => {
               icon={getImage(data.tokenInterfaceIcon)}
               title="Governance"
               link="https://token.vega.xyz/governance"
-              text="Signal your support for a validator by staking tokens and vote on governance actions and proposals for network parameters, markets and assets."
+              text="Review and vote on governance proposals."
               type="DAPP"
             />
             <ToolBox

--- a/src/pages/governance/index.js
+++ b/src/pages/governance/index.js
@@ -132,7 +132,7 @@ const GovernancePage = ({ data }) => {
             />
             <ToolBox
               icon={getImage(data.tokenInterfaceIcon)}
-              title="Token interface"
+              title="Governance"
               link="https://token.vega.xyz/governance"
               text="Signal your support for a validator by staking tokens and vote on governance actions and proposals for network parameters, markets and assets."
               type="DAPP"


### PR DESCRIPTION
Changing 'Token Interface' title on card to 'Governance' in line with the new Use Vega tools naming