### PR TITLE
Update URL in 04-martingale-variates page

### DIFF
--- a/src/content/papers/04-martingale-variates.md
+++ b/src/content/papers/04-martingale-variates.md
@@ -3,7 +3,7 @@ title: Unbiased Deep Solvers for Linear Parametric PDEs
 description: This research is co-authored by Dr David Siska and provides several algorithms for how to train appropriate neural networks that can be used to price derivatives and tests to validate them.
 links:
   - title: View PDF
-    link: https://www.tandfonline.com/doi/pdf/10.1080/1350486X.2022.2030773?needAccess=true
+    link: https://www.tandfonline.com/doi/pdf/10.1080/1350486X.2022.2030773
 position: 4
 category: Implementations
 ---


### PR DESCRIPTION
Removing the '?needAccess=true' from the end in just on the off chance it was that that was making it go to the interim CloudFlare page which is failing the cypress tests