### PR TITLE
chore: update add issues to project action

### DIFF
--- a/.github/workflows/add_issue_new_projects.yml
+++ b/.github/workflows/add_issue_new_projects.yml
@@ -1,37 +1,38 @@
 ---
 
-name: Add Issues To Project Board
+name: "Add Issues To Project Board"
 
 "on":
   issues:
-    types: [opened]
+    types:
+      - opened
+env:
+  GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+  PROJECT_ID: ${{ secrets.FRONT_END_PROJECT_ID }}
+  ISSUE_ID: ${{ github.event.issue.node_id }}
+  USER: ${{ github.actor }}
+  LABEL_ID: "LA_kwDODt173M8AAAABDttngQ"
 
 jobs:
-  add_issue:
+  add_issue_frontend:
     runs-on: ubuntu-latest
     steps:
-      - name: Add issue project board
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
-          PROJECT_ID: ${{ secrets.FRONT_END_PROJECT_ID }}
-          ISSUE_ID: ${{ github.event.issue.node_id }}
+      - name: "Add to front end project board"
         run: |
           gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
+            mutation($user:String!, $project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+                item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID -f user=$USER
 
-  label_issues:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Add "website" label
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
-        with:
-          add-labels: "website"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Add repo identifier label"
+        run: |
+          gh api graphql -f query='
+            mutation($user:String!, $issue:ID!, $label:[ID!]!) {
+              addLabelsToLabelable(input: {clientMutationId: $user, labelableId: $issue, labelIds: $label}) {
+                clientMutationId
+              }
+            }' -f label=$LABEL_ID -f issue=$ISSUE_ID -f user=$USER


### PR DESCRIPTION
The GitHub projects API has been replaced with ProjectsV2. This PR corrects the add issues to project action.

Also removes the external GH action and replaces with a simple GQL mutation for labelling