### PR TITLE
Create E2ETests yml

### DIFF
--- a/.github/workflows/E2ETests.yml
+++ b/.github/workflows/E2ETests.yml
@@ -1,0 +1,40 @@
+name: End-to-end tests
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-20.04
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving Cypress Cloud hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # run n copies of the current job in parallel
+        containers: [1]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: 'vegaprotocol/vega-website-cypress-tests'
+             
+      # Install NPM dependencies, cache them correctly
+      # and run all Cypress tests
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        with:
+          wait-on: "https://vega.xyz"
+          #record: true
+         # parallel: true
+        env:
+          #CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          # Recommended: pass the GitHub token lets this action correctly
+          # determine the unique run id necessary to re-run the checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+     # - name: Print Cypress Cloud URL
+       # run: |
+       #   echo Cypress finished with: ${{ steps.cypress.outcome }}
+        #  echo See results at ${{ steps.cypress.outputs.dashboardUrl }}


### PR DESCRIPTION
New workflow for running E2E tests on PRs.

I have commented out a few features as they require the cypress record key.

Someone with admin access to the project will need to add the secret, and then we can enable the commented out features.