### PR TITLE
Update E2E action to record runs

### DIFF
--- a/.github/workflows/E2ETests.yml
+++ b/.github/workflows/E2ETests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # run n copies of the current job in parallel
-        containers: [1]
+        containers: [2]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/E2ETests.yml
+++ b/.github/workflows/E2ETests.yml
@@ -27,10 +27,10 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           wait-on: "https://vega.xyz"
-          #record: true
-         # parallel: true
+          record: true
+          parallel: true
         env:
-          #CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update E2E action to record runs. Also enable parallel test running to speed up the tests slightly.