### PR TITLE
chore: update link to Oregon Trail whats left

### DIFF
--- a/src/content/roadmap/03/content.en.md
+++ b/src/content/roadmap/03/content.en.md
@@ -1,5 +1,5 @@
 ---
-step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/vegaprotocol/vega/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22%F0%9F%A4%A0+Oregon+Trail%22">See what's left</a>
+step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/vegaprotocol/vega/milestone/45">See what's left</a>
 title: Alpha Mainnet
 ---
 

--- a/src/content/roadmap/03/content.en.md
+++ b/src/content/roadmap/03/content.en.md
@@ -1,5 +1,5 @@
 ---
-step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/vegaprotocol/vega/milestone/45">See what's left</a>
+step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/orgs/vegaprotocol/projects/125/views/2">See what's left</a>
 title: Alpha Mainnet
 ---
 

--- a/src/content/roadmap/03/content.es.md
+++ b/src/content/roadmap/03/content.es.md
@@ -1,5 +1,5 @@
 ---
-step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/vegaprotocol/vega/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22%F0%9F%A4%A0+Oregon+Trail%22">See what's left</a>
+step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/vegaprotocol/vega/milestone/45">See what's left</a>
 title: Alpha Mainnet
 ---
 

--- a/src/content/roadmap/03/content.es.md
+++ b/src/content/roadmap/03/content.es.md
@@ -1,5 +1,5 @@
 ---
-step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/vegaprotocol/vega/milestone/45">See what's left</a>
+step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/orgs/vegaprotocol/projects/125/views/2">See what's left</a>
 title: Alpha Mainnet
 ---
 

--- a/src/content/roadmap/03/content.ru.md
+++ b/src/content/roadmap/03/content.ru.md
@@ -1,5 +1,5 @@
 ---
-step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/vegaprotocol/vega/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22%F0%9F%A4%A0+Oregon+Trail%22">See what's left</a>
+step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/vegaprotocol/vega/milestone/45">See what's left</a>
 title: Alpha Mainnet
 ---
 

--- a/src/content/roadmap/03/content.ru.md
+++ b/src/content/roadmap/03/content.ru.md
@@ -1,5 +1,5 @@
 ---
-step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/vegaprotocol/vega/milestone/45">See what's left</a>
+step_title: <strike>2022 H2</strike> <i>any week now!</i><br><a class="underline hover:no-underline" target="_blank" href="https://github.com/orgs/vegaprotocol/projects/125/views/2">See what's left</a>
 title: Alpha Mainnet
 ---
 


### PR DESCRIPTION
I think that the link to the milestone gives a better more accurate view on whats remaining as it also includes PRs and not just issues.

I think this then will match the [Alpha mainnet](https://github.com/orgs/vegaprotocol/projects/125/views/2) project board and cause less confusion.

