### PR TITLE
Update substack newsletter link - community page

### DIFF
--- a/src/pages/community/index.js
+++ b/src/pages/community/index.js
@@ -96,7 +96,7 @@ const CommunityPage = ({ data }) => {
             text={t(
               "Roll up! Roll up! Vega's bi-weekly highlights newsletter."
             )}
-            link="https://vegacommunity.substack.com/subscribe"
+            link="https://vegacommunity.substack.com"
             icon={getImage(data.iconSubstack)}
           />
           <ToolBox


### PR DESCRIPTION
/subscribe URL stopped working so updating so removing this from the subscript to newsletter links across the site