### PR TITLE
Prevent redundant scrollbars showing beneath tabs

### DIFF
--- a/src/components/UI/Table.js
+++ b/src/components/UI/Table.js
@@ -19,7 +19,7 @@ const Row = ({ children }) => {
 // TODO - This table needs generalising, it's specific to validator rewards
 const Table = ({ headings, rows }) => {
   return (
-    <div className="overflow-x-scroll">
+    <div className="overflow-x-auto">
       <table className="w-full max-w-[100vw] border-b border-[#525252] text-left">
         <tbody>
           {headings.map((heading, idx) => (

--- a/src/gatsby-types.d.ts
+++ b/src/gatsby-types.d.ts
@@ -11365,6 +11365,7 @@ type MediumPostVirtualsTagsMetadataCoverImage = {
   readonly isFeatured: Maybe<Scalars['Boolean']>;
   readonly originalHeight: Maybe<Scalars['Int']>;
   readonly originalWidth: Maybe<Scalars['Int']>;
+  readonly repairedAt: Maybe<Scalars['Int']>;
   readonly unsplashPhotoId: Maybe<Scalars['String']>;
 };
 
@@ -11379,6 +11380,7 @@ type MediumPostVirtualsTagsMetadataCoverImageFilterInput = {
   readonly isFeatured: InputMaybe<BooleanQueryOperatorInput>;
   readonly originalHeight: InputMaybe<IntQueryOperatorInput>;
   readonly originalWidth: InputMaybe<IntQueryOperatorInput>;
+  readonly repairedAt: InputMaybe<IntQueryOperatorInput>;
   readonly unsplashPhotoId: InputMaybe<StringQueryOperatorInput>;
 };
 

--- a/src/pages/key-concepts/index.js
+++ b/src/pages/key-concepts/index.js
@@ -109,7 +109,7 @@ const KeyConceptsPage = () => {
         <div className="relative z-30">
           <Sticky enabled={true}>
             <div className="bg-white dark:bg-black">
-              <div className="mx-auto overflow-y-hidden overflow-x-scroll whitespace-nowrap border-b border-vega-mid-grey px-6 md:flex md:justify-center md:gap-x-8 md:whitespace-normal md:px-0">
+              <div className="mx-auto overflow-x-auto overflow-y-hidden whitespace-nowrap border-b border-vega-mid-grey px-6 md:flex md:justify-center md:gap-x-8 md:whitespace-normal md:px-0">
                 <ScrollSpy
                   items={['good', 'better', 'mature']}
                   currentClassName="border-b-current"

--- a/src/pages/use/index.js
+++ b/src/pages/use/index.js
@@ -201,7 +201,7 @@ const UsePage = ({ data }) => {
           </div>
         </div>
         <div className="mx-auto max-w-[90rem] md:px-6 lg:px-8">
-          <div className="mx-auto overflow-y-hidden overflow-x-scroll whitespace-nowrap border-b border-vega-mid-grey px-6 text-center md:flex md:justify-center md:gap-x-8 md:whitespace-normal">
+          <div className="mx-auto overflow-x-auto overflow-y-hidden whitespace-nowrap border-b border-vega-mid-grey px-6 text-center md:flex md:justify-center md:gap-x-8 md:whitespace-normal">
             <button
               tabIndex={0}
               onClick={() => changeFilter(null)}


### PR DESCRIPTION
Use overflow auto instead of scroll to ensure scroll bars only show when needed