### PR TITLE
Fix title and description of rewards page

### DIFF
--- a/src/pages/rewards/index.js
+++ b/src/pages/rewards/index.js
@@ -62,9 +62,9 @@ const RewardsPage = ({ data }) => {
   return (
     <Layout>
       <Seo
-        title={t('Develop with Vega')}
+        title={t('Rewards')}
         description={t(
-          'Get access to the Vega APIs, contribute to the source code, earn bounties and be rewarded for building the future of DeFi.'
+          'Get rewarded for participating in the future of DeFi.'
         )}
       />
       {missingTranslations && <TranslationsBanner />}


### PR DESCRIPTION
It appeared to be a copy past job of the develop page so was showing the title and description for the develop page. I've changed this to be rewards specific