### PR TITLE
Fix redirect of disallowed links, add ipfs hash list

### DIFF
--- a/interstitial-allow.json
+++ b/interstitial-allow.json
@@ -1,3 +1,6 @@
 {
-  "allowed": ["https://console.fairground.wtf"]
+  "ipfsGateway": "https://#1#.#2#.cf-ipfs.com/",
+  "allowedSites": ["https://console.fairground.wtf"],
+  "allowedIPFS": [],
+  "allowedIPNS": []
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -67,3 +67,6 @@
   to = "https://vega.xyz/:splat"
   status = 301
   force = true
+
+# IPFS REDIRECT START
+# IPFS REDIRECT END


### PR DESCRIPTION
The interstitial page will need to direct users to IPFS deploys for some
apps. Rather than require the gateway URLs to be hardcoded somewhere,
this PR extends the allow list JSON file to have a variable for
configuring an IPFS gateway, and adds IPFS and IPNS specific support.

Also fixes a bug whereby disallowed links would still be redirected,
even after showing a 404.

- Fix redirect on notFound pages
- Add ipfs and ipns specific support
- Update interstitial-allow.json format

Closes #554
