### PR TITLE
fix: Add 'live' argument to liquidityProvisionsConnection query

### DIFF
--- a/src/hooks/use-market-liquidity.ts
+++ b/src/hooks/use-market-liquidity.ts
@@ -64,7 +64,7 @@ const MarketLpDocument = gql`
         trigger
         marketValueProxy
       }
-      liquidityProvisionsConnection {
+      liquidityProvisionsConnection(live: true) {
         edges {
           node {
             ...LiquidityProvisionFields


### PR DESCRIPTION
This will return only live LPs, which is the number we want (it should match the value in supplied stake).

This PR gets the _correct number_ from the API - but does not resolve the decimal place issues for either the Total Staked or Fee - both of which will need a change on the healthbar component in the monorepo, which I'll follow this with.